### PR TITLE
Add k8s example leveraging Rancher provider in Terraform

### DIFF
--- a/example_ha/kubernetes-env/Makefile
+++ b/example_ha/kubernetes-env/Makefile
@@ -1,0 +1,1 @@
+../Makefile

--- a/example_ha/kubernetes-env/files/userdata.template
+++ b/example_ha/kubernetes-env/files/userdata.template
@@ -1,0 +1,28 @@
+#cloud-config
+write_files:
+  - path: /etc/rc.local
+    permissions: "0755"
+    owner: root
+    content: |
+      #!/bin/bash
+      wait-for-docker
+      IP="$(wget -qO - http://169.254.169.254/2016-06-30/meta-data/${ip-addr})"
+      mkdir -p /var/lib/rancher/etc
+      echo "export CATTLE_AGENT_IP=$${IP}" >> /var/lib/rancher/etc/agent.conf
+      ${rancher_registration_command}
+rancher:
+  docker:
+    engine: docker-1.12.6
+    log_driver: "json-file"
+    log_opts:
+      max-file: "3"
+      max-size: "100m"
+      labels: "prodservices,production"
+  services_include:
+    kernel-headers: "true"
+  services:
+    giddyup-health:
+      image: cloudnautique/giddyup:v0.14.0
+      ports:
+        - 1620:1620
+      command: /giddyup health

--- a/example_ha/kubernetes-env/kubernetes-env.tfvars
+++ b/example_ha/kubernetes-env/kubernetes-env.tfvars
@@ -1,0 +1,19 @@
+name = "k8s-ha-demo"
+
+vpc_id = "<vpcid>"
+
+ipsec_node_cidrs = "cidr_for_aws_nodes"
+
+ssh_key_name = "<ssh-key-name>"
+
+subnet_ids = "subnet-<id>"
+
+subnet_cidrs = "<cidr for subnets>"
+
+aws_instance_type = "t2.medium"
+
+cattle_agent_ip = "local-ipv4"
+
+project_template_id = "1pt6"
+
+rancher_api_url = "<rancher_url>"

--- a/example_ha/kubernetes-env/main.tf
+++ b/example_ha/kubernetes-env/main.tf
@@ -1,0 +1,130 @@
+provider "rancher" {
+  api_url    = "${var.rancher_api_url}"
+  access_key = "${var.rancher_access_key}"
+  secret_key = "${var.rancher_secret_key}"
+}
+
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "${var.aws_region}"
+}
+
+resource "rancher_environment" "ha_k8s" {
+   name                = "${var.name}"
+   project_template_id = "${var.project_template_id}"
+}
+
+resource "rancher_registration_token" "etcd_nodes" {
+   name           = "etcd_nodes"
+   environment_id = "${rancher_environment.ha_k8s.id}"
+
+   host_labels {
+     etcd = "true"
+   }
+}
+
+resource "rancher_registration_token" "orchestration_nodes" {
+   name  = "etcd_nodes"
+   environment_id = "${rancher_environment.ha_k8s.id}"
+
+   host_labels {
+     orchestration = "true"
+   }
+}
+
+resource "rancher_registration_token" "compute_nodes" {
+   name  = "etcd_nodes"
+   environment_id = "${rancher_environment.ha_k8s.id}"
+
+   host_labels {
+     compute = "true"
+   }
+}
+
+data "template_file" "etcd_userdata" {
+  template = "${file("${path.module}/files/userdata.template")}"
+
+  vars {
+    rancher_registration_command = "${rancher_registration_token.etcd_nodes.command}"
+    ip-addr                      = "${var.cattle_agent_ip}"
+  }
+}
+
+data "template_file" "orchestration_userdata" {
+  template = "${file("${path.module}/files/userdata.template")}"
+
+  vars {
+    rancher_registration_command = "${rancher_registration_token.orchestration_nodes.command}"
+    ip-addr                      = "${var.cattle_agent_ip}"
+  }
+}
+
+data "template_file" "compute_userdata" {
+  template = "${file("${path.module}/files/userdata.template")}"
+
+  vars {
+    rancher_registration_command = "${rancher_registration_token.compute_nodes.command}"
+    ip-addr                      = "${var.cattle_agent_ip}"
+  }
+}
+
+module "ipsec_sg" {
+  source = "../../modules/aws/network/security_groups/env-ipsec"
+
+  vpc_id            = "${var.vpc_id}"
+  name              = "${var.name}-ipsec-sg"
+  environment_cidrs = "${var.ipsec_node_cidrs}"
+}
+
+module "etcd_asg" {
+  source = "../../modules/aws/compute/asg"
+
+  name                = "${var.name}-etcd"
+  userdata            = "${data.template_file.etcd_userdata.rendered}"
+  health_check_type   = "EC2"
+  ssh_key_name        = "${var.ssh_key_name}"
+  security_groups     = "${module.ipsec_sg.ipsec_id}"
+  lb_ids              = ""
+  health_check_target = "HTTP:1620/ping"
+  ami_id              = "ami-5c5a3f4a"
+  subnet_ids          = "${var.subnet_ids}"
+  subnet_cidrs        = "${var.subnet_cidrs}"
+  vpc_id              = "${var.vpc_id}"
+  instance_type       = "${var.aws_instance_type}"
+}
+
+module "orchestration_asg" {
+  source = "../../modules/aws/compute/asg"
+
+  name                = "${var.name}-orchestration"
+  userdata            = "${data.template_file.orchestration_userdata.rendered}"
+  health_check_type   = "EC2"
+  ssh_key_name        = "${var.ssh_key_name}"
+  security_groups     = "${module.ipsec_sg.ipsec_id}"
+  lb_ids              = ""
+  health_check_target = "HTTP:1620/ping"
+  ami_id              = "ami-5c5a3f4a"
+  subnet_ids          = "${var.subnet_ids}"
+  subnet_cidrs        = "${var.subnet_cidrs}"
+  vpc_id              = "${var.vpc_id}"
+  instance_type       = "${var.aws_instance_type}"
+}
+
+module "compute_asg" {
+  source = "../../modules/aws/compute/asg"
+
+  name                = "${var.name}-compute"
+  userdata            = "${data.template_file.compute_userdata.rendered}"
+  health_check_type   = "EC2"
+  ssh_key_name        = "${var.ssh_key_name}"
+  security_groups     = "${module.ipsec_sg.ipsec_id}"
+  lb_ids              = ""
+  health_check_target = "HTTP:1620/ping"
+  ami_id              = "ami-5c5a3f4a"
+  subnet_ids          = "${var.subnet_ids}"
+  subnet_cidrs        = "${var.subnet_cidrs}"
+  vpc_id              = "${var.vpc_id}"
+  instance_type       = "${var.aws_instance_type}"
+}
+

--- a/example_ha/kubernetes-env/variables.tf
+++ b/example_ha/kubernetes-env/variables.tf
@@ -1,0 +1,29 @@
+variable "name" {}
+
+variable "project_template_id" {}
+
+variable "rancher_access_key" {}
+
+variable "rancher_secret_key" {}
+
+variable "aws_access_key" {}
+
+variable "aws_secret_key" {}
+
+variable "aws_region" {}
+
+variable "vpc_id" {}
+
+variable "ipsec_node_cidrs" {}
+
+variable "ssh_key_name" {}
+
+variable "subnet_ids" {}
+
+variable "subnet_cidrs" {}
+
+variable "aws_instance_type" {}
+
+variable "cattle_agent_ip" {}
+
+variable "rancher_api_url" {}

--- a/modules/aws/network/security_groups/env-ipsec/main.tf
+++ b/modules/aws/network/security_groups/env-ipsec/main.tf
@@ -1,0 +1,49 @@
+variable "name" {}
+
+variable "vpc_id" {}
+
+variable "environment_cidrs" {}
+
+resource "aws_security_group" "rancher_ip_sec" {
+  name   = "${var.name}-sg"
+  vpc_id = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port = 0
+    to_port   = 65535
+    protocol  = "tcp"
+    self      = true
+  }
+
+  ingress {
+    from_port = 0
+    to_port   = 65535
+    protocol  = "udp"
+    self      = true
+  }
+
+  ingress {
+    from_port   = 500
+    to_port     = 500
+    protocol    = "udp"
+    cidr_blocks = ["${split(",", var.environment_cidrs)}"]
+  }
+
+  ingress {
+    from_port   = 4500
+    to_port     = 4500
+    protocol    = "udp"
+    cidr_blocks = ["${split(",", var.environment_cidrs)}"]
+  }
+}
+
+output "ipsec_id" {
+  value = "${aws_security_group.rancher_ip_sec.id}"
+}


### PR DESCRIPTION
This provides an example configuration for setting up an HA K8s env
It requires that a project template is created ahead of time with
the appropriate k8s configuration.

It will require the use of TF with an updated Rancher provider with
V2 API support.