### PR TITLE
Modifying name and id outputs to use splat syntax

### DIFF
--- a/modules/aws/compute/asg/asg.tf
+++ b/modules/aws/compute/asg/asg.tf
@@ -88,9 +88,9 @@ resource "aws_autoscaling_group" "alb" {
 }
 
 output "name" {
-  value = "${element(concat(aws_autoscaling_group.alb.name, aws_autoscaling_group.elb.name), var.use_elb)}"
+  value = "${element(concat(aws_autoscaling_group.alb.*.name, aws_autoscaling_group.elb.*.name), var.use_elb)}"
 }
 
 output "id" {
-  value = "${element(concat(aws_autoscaling_group.alb.id, aws_autoscaling_group.elb.id), var.use_elb)}"
+  value = "${element(concat(aws_autoscaling_group.alb.*.id, aws_autoscaling_group.elb.*.id), var.use_elb)}"
 }


### PR DESCRIPTION
Fix for the following errors while running terraform plan:

```
Warning: output "name": must use splat syntax to access aws_autoscaling_group.alb attribute "name", because it has "count" set; use aws_autoscaling_group.alb.*.name to obtain a list of the attributes across all instances

Warning: output "name": must use splat syntax to access aws_autoscaling_group.elb attribute "name", because it has "count" set; use aws_autoscaling_group.elb.*.name to obtain a list of the attributes across all instances

Warning: output "id": must use splat syntax to access aws_autoscaling_group.alb attribute "id", because it has "count" set; use aws_autoscaling_group.alb.*.id to obtain a list of the attributes across all instances

Warning: output "id": must use splat syntax to access aws_autoscaling_group.elb attribute "id", because it has "count" set; use aws_autoscaling_group.elb.*.id to obtain a list of the attributes across all instances
```
  
  
...which cause the following two errors during `tf plan`:
```
Error: Error running plan: 2 error(s) occurred:

* module.compute.module.asg.output.name: Resource 'aws_autoscaling_group.alb' not found for variable 'aws_autoscaling_group.alb.name'
* module.compute.module.asg.output.id: Resource 'aws_autoscaling_group.alb' not found for variable 'aws_autoscaling_group.alb.id'
```