### PR TITLE
Fix typo in aws_region variable

### DIFF
--- a/example_ha/aws/main-vars.tfvars
+++ b/example_ha/aws/main-vars.tfvars
@@ -2,8 +2,8 @@
 # Best to keep your private access keys here as they will
 # be used by multiple components
 ##
-aws_access_key = "<your_key>"
+aws_access_key = "<your_access_key>"
 
-aws_secret_key = "<your_key>"
+aws_secret_key = "<your_secret_key>"
 
-ws_region = "us-west-1"
+aws_region = "<your_region>"


### PR DESCRIPTION
The aws_region value was not being found by the modules network, database, etc because it was being defined as ws_region without the A.

I'm also updating the example values to make them more clear.